### PR TITLE
Switch input prompts to command-line args, allow input files in other directories.

### DIFF
--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -511,24 +511,6 @@ class BB_log:
             heads.append(headsdict)
         return heads
 
-    def logfinder(self, fpath):
-        path, file = os.path.split(fpath)
-        name = file[:-3]
-        flist = os.listdir(path)
-        csvlist =   []
-        csv_sizes = []
-        eventlist =  []
-
-        for i in range(1, 99):
-            csvname = name+'_temp'+str(i)+'.01.csv'
-            eventname = name+'_temp'+str(i)+'.01.event'
-            if csvname not in flist: break
-            csvlist.append(csvname)
-            eventlist.append(eventname)
-        for csv in csvlist:
-            csv_sizes.append(os.path.getsize(path+'/'+csv))
-        return csvlist, csv_sizes, eventlist
-
     def decode(self, fpath):
         """Splits out one BBL per recorded session and converts each to CSV."""
         with open(fpath, 'r') as text_log_view:

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -386,8 +386,7 @@ class CSV_log:
 class BB_log:
     def __init__(self, filepath, name, blackbox_decode):
         self.blackbox_decode_bin_path = blackbox_decode
-        self.fpath = self.check_ends(filepath)
-        self.path, self.file = os.path.split(self.fpath)
+        self.path, self.file = os.path.split(filepath)
         self.name = name
 
         #self.maketemp(self.path)
@@ -396,13 +395,6 @@ class BB_log:
         self.figs = self._csv_iter(self.heads)
 
         self.deletejunk(self.loglist)
-
-    def check_ends(self, filepath):
-        filepath = str(filepath)
-        if filepath[-1]=='"' or filepath[-1]=="'":
-            return filepath[1:-1]
-        else:
-            return filepath
 
     def maketemp(self, path):
         os.mkdir(path+'/tmp')
@@ -572,6 +564,14 @@ def main(log_file_path, plot_name, blackbox_decode):
         plt.show()
 
 
+def strip_quotes(filepath):
+    """Strips single or double quotes from a string."""
+    if filepath[-1]=='"' or filepath[-1]=="'":
+        return filepath[1:-1]
+    else:
+        return filepath
+
+
 if __name__ == "__main__":
     logging.basicConfig(
         format='%(levelname)s %(asctime)s %(filename)s:%(lineno)s: %(message)s',
@@ -593,4 +593,4 @@ if __name__ == "__main__":
             % os.path.abspath(args.blackbox_decode))
     logging.info('Decoding with %r', os.path.abspath(args.blackbox_decode))
 
-    main(args.log, args.name, args.blackbox_decode)
+    main(strip_quotes(args.log), args.name, args.blackbox_decode)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -389,7 +389,7 @@ class CSV_log:
 class BB_log:
     def __init__(self, log_file_path, name, blackbox_decode):
         self.blackbox_decode_bin_path = blackbox_decode
-        self.tmp_dir = os.path.join(os.path.dirname(log_file_path), name or 'tmp')
+        self.tmp_dir = os.path.join(os.path.dirname(log_file_path), name)
         if not os.path.isdir(self.tmp_dir):
             os.makedirs(self.tmp_dir)
         self.name = name
@@ -562,11 +562,8 @@ def run_analysis(log_file_path, plot_name, blackbox_decode):
 
 
 def strip_quotes(filepath):
-    """Strips single or double quotes from a string."""
-    if filepath[-1]=='"' or filepath[-1]=="'":
-        return filepath[1:-1]
-    else:
-        return filepath
+    """Strips single or double quotes and extra whitespace from a string."""
+    return filepath.strip().strip("'").strip('"')
 
 
 def clean_path(path):
@@ -582,7 +579,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '-l', '--log', action='append',
         help='BBL log file(s) to analyse. Omit for interactive prompt.')
-    parser.add_argument('-n', '--name', default='', help='Plot name.')
+    parser.add_argument('-n', '--name', default='tmp', help='Plot name.')
     parser.add_argument(
         '--blackbox_decode',
         default=os.path.join(os.getcwd(), 'Blackbox_decode.exe'),

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -310,7 +310,7 @@ class CSV_log:
             +' | Throttle min/tpa/max: ' + self.headdict['minThrottle']+'/'+self.headdict['tpa_breakpoint']+'/'+self.headdict['maxThrottle'] \
             + ' | dynThrPID: ' + self.headdict['dynThrottle']+ '| D-TermSP: ' + self.headdict['dTermSetPoint']+'| vbatComp: ' + self.headdict['vbatComp']
 
-        plt.text(0.5, 0, t, ha='left', rotation=90, wrap=True, color='grey', alpha=0.5, fontsize=8)
+        plt.text(0.5, 0, t, ha='left', rotation=90, color='grey', alpha=0.5, fontsize=8)
         ax4.axis('off')
         plt.savefig(self.file[:-13] + self.name + '_' + str(self.headdict['logNum'])+'.png')
         #plt.show()
@@ -553,9 +553,9 @@ def main(log_file_path, plot_name, blackbox_decode):
     logging.info(Version)
     logging.info('Hello Pilot!')
 
-    while True:
-        test = BB_log(log_file_path, plot_name, blackbox_decode)
-        plt.show()
+    test = BB_log(log_file_path, plot_name, blackbox_decode)
+    logging.info('Analysis complete, showing plot. (Close plot to exit.)')
+    plt.show()
 
 
 def strip_quotes(filepath):

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -517,7 +517,7 @@ class BB_log:
         csv_sizes = []
         eventlist =  []
 
-        for i in range(1, 99, 1):
+        for i in range(1, 99):
             csvname = name+'_temp'+str(i)+'.01.csv'
             eventname = name+'_temp'+str(i)+'.01.event'
             if csvname not in flist: break

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -125,7 +125,11 @@ class Trace:
 
     def wiener_deconvolution(self, input, output, smooth):      # input/output are twosimensional
         pad = len(input[0]) - 2*(len(input[0])%1024)            # padding to potence of 2, increases transform speed
-        #print 'pad:', pad, 'len:', len(inp[0])
+        if pad < 0:
+            logging.warning(
+                'Clamping padding value %d < 0 from length %d to 0.'
+                % (pad, len(input[0])))
+            pad = 0
         input = np.pad(input, [[0,0],[0,pad]], mode='constant')
         output = np.pad(output, [[0, 0], [0, pad]], mode='constant')
         H = np.fft.fft(input, axis=-1, norm='ortho')

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -123,13 +123,8 @@ class Trace:
             stacks[k]=np.array(stacks[k])
         return stacks
 
-    def wiener_deconvolution(self, input, output, smooth):      # input/output are twosimensional
-        pad = len(input[0]) - 2*(len(input[0])%1024)            # padding to potence of 2, increases transform speed
-        if pad < 0:
-            logging.warning(
-                'Clamping padding value %d < 0 from length %d to 0.'
-                % (pad, len(input[0])))
-            pad = 0
+    def wiener_deconvolution(self, input, output, smooth):      # input/output are two-dimensional
+        pad = len(input[0]) + (1024 - (len(input[0]) % 1024))   # padding to power of 2, increases transform speed
         input = np.pad(input, [[0,0],[0,pad]], mode='constant')
         output = np.pad(output, [[0, 0], [0, pad]], mode='constant')
         H = np.fft.fft(input, axis=-1, norm='ortho')

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -1,3 +1,5 @@
+import argparse
+import logging
 import os
 import numpy as np
 from pandas import read_csv
@@ -196,7 +198,7 @@ class CSV_log:
 
         self.data = self.readcsv(self.file)
 
-        print 'Processing:'
+        logging.info('Processing:')
         self.traces = self.find_traces(self.data)
         self.roll, self.pitch, self.yaw = self.__analyze()
         self.fig = self.plot_all([self.roll, self.pitch, self.yaw])
@@ -312,13 +314,13 @@ class CSV_log:
     def __analyze(self):
         analyzed = []
         for t in self.traces:
-            print t['name'] + '...   ',
+            logging.info(t['name'] + '...   ')
             analyzed.append(Trace(t))
-            print 'Done!'
+            logging.info('\tDone!')
         return analyzed
 
     def readcsv(self, fpath):
-        print 'Reading log '+str(self.headdict['logNum'][0])+'...   ',
+        logging.info('Reading log '+str(self.headdict['logNum'][0])+'...   ')
         datdic = {}
         data = read_csv(fpath, header=0, skipinitialspace=1)
         datdic.update({'time_us': data['time (us)'].values * 1e-6})
@@ -334,7 +336,7 @@ class CSV_log:
             elif 'gyroData[0]' in data.keys():
                 datdic.update({'gyroData' + i: data['gyroData[' + i+']'].values})
             else:
-                print 'No gyro trace found!'
+                logging.warning('No gyro trace found!')
 
         #plt.figure()
         #for a in acc:
@@ -354,7 +356,7 @@ class CSV_log:
         #print deconvolved_sm
 
         #plt.show()
-        print 'Done!'
+        logging.info('\tDone!')
 
         return datdic
 
@@ -411,7 +413,7 @@ class BB_log:
             try:
                 os.remove(l[:-3]+'01.event')
             except:
-                print 'No .event file of '+l+' found.'
+                logging.warning('No .event file of '+l+' found.')
         return
 
     def _csv_iter(self, heads):
@@ -553,7 +555,7 @@ class BB_log:
                     msg = os.system('blackbox_decode.exe' + ' '+t)
                     loglist.append(t)
                 except:
-                    print 'Error in Blackbox_decode'
+                    logging.error('Error in Blackbox_decode', exc_info=True)
             else:
                 os.remove(t)
         return loglist
@@ -565,12 +567,13 @@ def main():
     #test = BB_log('path/file.bbl', 'addidtional name')
     #plt.show()
 
-    print Version +'\n\n'
-    print 'Hello Pilot!'
-    print 'This program uses Blackbox_decode:\n' \
+    logging.info(Version)
+    logging.info('Hello Pilot!')
+    logging.info(
+          'This program uses Blackbox_decode:\n' \
           'https://github.com/cleanflight/blackbox-tools/releases\n' \
           'to generate .csv files from your log.\n' \
-          'Please put logfiles, Blackbox_decode.exe and this program into a single folder.\n'
+          'Please put logfiles, Blackbox_decode.exe and this program into a single folder.\n')
 
     while True:
         file = raw_input("Place your log here: \n-->\n")
@@ -580,4 +583,7 @@ def main():
         plt.show()
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        format='%(levelname)s %(asctime)s %(filename)s:%(lineno)s: %(message)s',
+        level=logging.INFO)
     main()

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -570,7 +570,8 @@ if __name__ == "__main__":
     parser.add_argument('log', help='BBL log file to analyse.')
     parser.add_argument('-n', '--name', default='', help='Plot name.')
     parser.add_argument(
-        '--blackbox_decode', default='./Blackbox_decode.exe',
+        '--blackbox_decode',
+        default=os.path.join(os.getcwd(), 'Blackbox_decode.exe'),
         help='Path to Blackbox_decode.exe.')
     args = parser.parse_args()
 

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -579,12 +579,16 @@ if __name__ == "__main__":
         help='Path to Blackbox_decode.exe.')
     args = parser.parse_args()
 
-    if not os.path.isfile(args.blackbox_decode):
+    blackbox_decode_path = os.path.abspath(os.path.expanduser(args.blackbox_decode))
+    if not os.path.isfile(blackbox_decode_path):
         parser.error(
             ('Could not find Blackbox_decode.exe (used to generate CSVs from '
              'your BBL file) at %s. You may need to install it from '
              'https://github.com/cleanflight/blackbox-tools/releases.')
-            % os.path.abspath(args.blackbox_decode))
-    logging.info('Decoding with %r', os.path.abspath(args.blackbox_decode))
+            % blackbox_decode_path)
+    logging.info('Decoding with %r' % blackbox_decode_path)
 
-    main(strip_quotes(args.log), args.name, args.blackbox_decode)
+    main(
+        os.path.abspath(os.path.expanduser(strip_quotes(args.log))),
+        args.name,
+        args.blackbox_decode)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import logging
 import os

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -2,6 +2,7 @@
 import argparse
 import logging
 import os
+import subprocess
 import numpy as np
 from pandas import read_csv
 import matplotlib.pyplot as plt
@@ -531,10 +532,11 @@ class BB_log:
             size_bytes = os.path.getsize(os.path.join(self.tmp_dir, bbl_session))
             if size_bytes > LOG_MIN_BYTES:
                 try:
-                    msg = os.system(self.blackbox_decode_bin_path + ' '+bbl_session)
+                    msg = subprocess.check_call([self.blackbox_decode_bin_path, bbl_session])
                     loglist.append(bbl_session)
                 except:
-                    logging.error('Error in Blackbox_decode of %r' % bbl_session)
+                    logging.error(
+                        'Error in Blackbox_decode of %r' % bbl_session, exc_info=True)
             else:
                 # There is often a small bogus session at the start of the file.
                 logging.warning(

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo pip3 install -r requirements.txt
 ## How to use this program:
 1. Record your log. Logs of 20s seem to give sufficient statistics. If it's slightly windy, longer logs can still give reasonable results. You can record multiple logs in one session: Each entry will yield a seperate plot.
 2. Place your logfiles, `blackbox_decode.exe` ([Windows download](https://github.com/cleanflight/blackbox-tools/releases/download/v0.4.3/blackbox-tools-0.4.3-windows.zip)) and `PID-Analyzer.exe` ([Windows download](http://bit.ly/PID-Analyzer)) in the same folder. You can also specify where to find these executables via command-line flags.
-3. Run `PID-Analyzer.exe` (this takes some seconds, it sets up a complete virtual python environment). Pass your `.BBL` file as the argument to `PID-Analyzer`.
+3. Run `PID-Analyzer.exe` (this takes some seconds, it sets up a complete virtual python environment). Either interactively enter your `.BBL` files, or pass your `.BBL` file(s) via flags, like `PID-Analyzer --log one.BBL --log two.BBL`.
 4. The logs are separated into temp files, read, analyzed and temp files deleted again.
 5. A plot window opens and a `.png` image is saved automatically.
 

--- a/README.md
+++ b/README.md
@@ -28,22 +28,20 @@ Keep in mind that if you go crazy on the throttle it will cause more distortion.
 This is the reason why the throttle and TPA threshold is additionally plotted.
 
 The whole thing is still under development and results/input of different and more experienced pilots will be appreciated!
- 
-## How to use this program:
-1. Record your log. Logs of 20s seem to give sufficient statistics. If it's slightly windy, longer logs can still give reasonable results. You can record multiple logs in one session: Each entry will yield a seperate plot. 
-2. Place your logfiles, [blackbox_decode.exe](https://github.com/cleanflight/blackbox-tools/releases/download/v0.4.3/blackbox-tools-0.4.3-windows.zip) and [PID-Analyzer.exe](http://bit.ly/PID-Analyzer) in the same folder. (<-- Download links)
-3. Run PID-Analyzer.exe (this takes some seconds, it sets up a complete virtual python environment)
-4. Drag and drop your file into the command window and press enter
-5. Type in an optional name that will be appended to the log name. Or don't. Press Enter.
-6. The logs are separated into temp files, read, analyzed and temp files deleted again. 
-7. A plot window opens and a .png image is saved automatically
 
-The windows executable includes a virtual python environment and only requires you to drag and drop your Betaflight blackbox logfile into the cmd window. 
+## How to use this program:
+1. Record your log. Logs of 20s seem to give sufficient statistics. If it's slightly windy, longer logs can still give reasonable results. You can record multiple logs in one session: Each entry will yield a seperate plot.
+2. Place your logfiles, `blackbox_decode.exe` ([Windows download](https://github.com/cleanflight/blackbox-tools/releases/download/v0.4.3/blackbox-tools-0.4.3-windows.zip)) and `PID-Analyzer.exe` ([Windows download](http://bit.ly/PID-Analyzer)) in the same folder. You can also specify where to find these executables via command-line flags.
+3. Run `PID-Analyzer.exe` (this takes some seconds, it sets up a complete virtual python environment). Pass your `.BBL` file as the argument to `PID-Analyzer`.
+4. The logs are separated into temp files, read, analyzed and temp files deleted again.
+5. A plot window opens and a `.png` image is saved automatically.
+
+The windows executable includes a virtual python environment and only requires you to drag and drop your Betaflight blackbox logfile into the cmd window.
 
 
 In case of problems (if the cmd closes for example), please report including the log file.
 
-It's only tested on Win10 and with 3.15/3.2 logs.
+Tested on Win10 and MacOS 10.10, with 3.15/3.2 logs.
 
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ This is the reason why the throttle and TPA threshold is additionally plotted.
 
 The whole thing is still under development and results/input of different and more experienced pilots will be appreciated!
 
+## Requirements
+
+To install required Python libraries, view the list of packages in `requirements.txt` or simply run:
+
+```
+sudo apt-get install python3-pip python3-tk
+sudo pip3 install -r requirements.txt
+```
+
 ## How to use this program:
 1. Record your log. Logs of 20s seem to give sufficient statistics. If it's slightly windy, longer logs can still give reasonable results. You can record multiple logs in one session: Each entry will yield a seperate plot.
 2. Place your logfiles, `blackbox_decode.exe` ([Windows download](https://github.com/cleanflight/blackbox-tools/releases/download/v0.4.3/blackbox-tools-0.4.3-windows.zip)) and `PID-Analyzer.exe` ([Windows download](http://bit.ly/PID-Analyzer)) in the same folder. You can also specify where to find these executables via command-line flags.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+pandas
+matplotlib


### PR DESCRIPTION
Hi Flo,

I've been struggling to tune my quad (there are low-frequency oscillations in flight), and wanted to try out your analyser! Thanks for sharing it.

I'm using a Mac, and ran into some errors trying to run the analysis; I made some changes as I was debugging.

* switched from print to logging, so it includes line numbers with messages
* switched from interactive input to command-line flags (part of custom blackbox_decode path and BBL files in different dirs)
* added a flag so I could pass in a custom blackbox_decode path
* adjusted file handling to support BBL files in a different directory from PID-Analyzer
* fixed / enabled putting analysis files in tmp subdirectory
* clamp padding values in deconvolution to non-negative (this one I don't really understand, I was just avoiding an exception downstream)

I hope any/all of those are useful! If they're close but not quite what you'd like, I'm also glad to make some followup tweaks; or if you'd rather keep the original style, no offense taken of course.