### PR TITLE
set default scaling equal across all noise plots

### DIFF
--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -391,7 +391,7 @@ class CSV_log:
         meanspec_max = np.max(meanspec*mask[:-1])
 
         if not self.check_lims_list(lims):
-            lims=np.array([[1,20],[1, 20], [1, 20], [0,meanspec_max*1.5]])
+            lims=np.array([[1,max_noise_gyro],[1, max_noise_debug], [1, max_noise_d], [0,meanspec_max*1.5]])
             if lims[0,1] == 1:
                 lims[0,1]=100.
             if lims[1, 1] == 1:
@@ -467,11 +467,6 @@ class CSV_log:
                                                       '- LPF only: set debug_mode = GYRO', horizontalalignment='center', verticalalignment = 'center',
                                                       transform = ax1.transAxes,fontdict={'color': 'white'})
 
-             if correctdebugmode == False: # if debug_mode not GYRO_SCALED, display warning
-                ax1.text(0.5, 0.5, 'warning: debug does not contain prefiltered gyro\n'
-                                                      'set debug_mode = GYRO_SCALED', horizontalalignment='center', verticalalignment = 'center',
-                                                      transform = ax1.transAxes,fontdict={'color': 'white'})
-                
             if i<2:
                 # dterm plots
                 ax2 = plt.subplot(gs1[1 + i * 8:1 + i * 8 + 8, 16:23])
@@ -680,8 +675,6 @@ class CSV_log:
     def readcsv(self, fpath):
         logging.info('Reading: Log '+str(self.headdict['logNum']))
         datdic = {}
-        global correctdebugmode
-        
         ### keycheck for 'usecols' only reads usefull traces, uncommend if needed
         wanted =  ['time (us)',
                    'rcCommand[0]', 'rcCommand[1]', 'rcCommand[2]', 'rcCommand[3]',
@@ -700,8 +693,6 @@ class CSV_log:
         datdic.update({'time_us': data['time (us)'].values * 1e-6})
         datdic.update({'throttle': data['rcCommand[3]'].values})
 
-        correctdebugmode = not np.any(data['debug[3]']) # if debug[3] contains data, correctdebugmode is False
-            
         for i in ['0', '1', '2']:
             datdic.update({'rcCommand' + i: data['rcCommand['+i+']'].values})
             #datdic.update({'PID loop in' + i: data['axisP[' + i + ']'].values})
@@ -973,7 +964,7 @@ if __name__ == "__main__":
         default=os.path.join(os.getcwd(), 'Blackbox_decode.exe'),
         help='Path to Blackbox_decode.exe.')
     parser.add_argument('-s', '--show', default='Y', help='Y = show plot window when done.\nN = Do not. \nDefault = Y')
-    parser.add_argument('-nb', '--noise_bounds', default='[[1.,20.],[1.,20.],[1.,20.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
+    parser.add_argument('-nb', '--noise_bounds', default='[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
     args = parser.parse_args()
 
     blackbox_decode_path = clean_path(args.blackbox_decode)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -391,7 +391,7 @@ class CSV_log:
         meanspec_max = np.max(meanspec*mask[:-1])
 
         if not self.check_lims_list(lims):
-            lims=np.array([[1,max_noise_gyro],[1, max_noise_debug], [1, max_noise_d], [0,meanspec_max*1.5]])
+            lims=np.array([[1,20],[1, 20], [1, 20], [0,meanspec_max*1.5]])
             if lims[0,1] == 1:
                 lims[0,1]=100.
             if lims[1, 1] == 1:

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -964,7 +964,7 @@ if __name__ == "__main__":
         default=os.path.join(os.getcwd(), 'Blackbox_decode.exe'),
         help='Path to Blackbox_decode.exe.')
     parser.add_argument('-s', '--show', default='Y', help='Y = show plot window when done.\nN = Do not. \nDefault = Y')
-    parser.add_argument('-nb', '--noise_bounds', default='[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
+    parser.add_argument('-nb', '--noise_bounds', default='[[1.,20.],[1.,20.],[1.,20.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
     args = parser.parse_args()
 
     blackbox_decode_path = clean_path(args.blackbox_decode)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -467,6 +467,11 @@ class CSV_log:
                                                       '- LPF only: set debug_mode = GYRO', horizontalalignment='center', verticalalignment = 'center',
                                                       transform = ax1.transAxes,fontdict={'color': 'white'})
 
+             if correctdebugmode == False: # if debug_mode not GYRO_SCALED, display warning
+                ax1.text(0.5, 0.5, 'warning: debug does not contain prefiltered gyro\n'
+                                                      'set debug_mode = GYRO_SCALED', horizontalalignment='center', verticalalignment = 'center',
+                                                      transform = ax1.transAxes,fontdict={'color': 'white'})
+                
             if i<2:
                 # dterm plots
                 ax2 = plt.subplot(gs1[1 + i * 8:1 + i * 8 + 8, 16:23])
@@ -675,6 +680,8 @@ class CSV_log:
     def readcsv(self, fpath):
         logging.info('Reading: Log '+str(self.headdict['logNum']))
         datdic = {}
+        global correctdebugmode
+        
         ### keycheck for 'usecols' only reads usefull traces, uncommend if needed
         wanted =  ['time (us)',
                    'rcCommand[0]', 'rcCommand[1]', 'rcCommand[2]', 'rcCommand[3]',
@@ -693,6 +700,8 @@ class CSV_log:
         datdic.update({'time_us': data['time (us)'].values * 1e-6})
         datdic.update({'throttle': data['rcCommand[3]'].values})
 
+        correctdebugmode = not np.any(data['debug[3]']) # if debug[3] contains data, correctdebugmode is False
+            
         for i in ['0', '1', '2']:
             datdic.update({'rcCommand' + i: data['rcCommand['+i+']'].values})
             #datdic.update({'PID loop in' + i: data['axisP[' + i + ']'].values})


### PR DESCRIPTION
I would really like to see default scaling set equal across all noise plots. Sometimes people upload these plots and are mislead by the fact that the post filtered gyro looks noisier than prefiltered, because the scaling is not comparable across plots. I realize the colorbar is there to help, but for practical purposes, it's rather misleading at a glance, and it is currently not possible to really make a direct clear comparison even using the colorbar. By scaling them the same, the differences in density of yellow hot spots is a true representation of the differences. Even if this results are over saturated for the pre-filtered gyro (debug) condition, this cond mainly serves as a benchmark anyway. 

It only requires a small change to line 398: lims=np.array([[1, 20],[1, 20], [1, 20], [0,meanspec_max*1.5]])
I think 1 to 20 is perfect across all. I think line 398 contains the default lims. Looks like it is set to detect the max value it sees for each axis and scale accordingly. Maybe there's a better way to just create another option called "equal-scaling" and make that default, and leave the current "auto" option if someone wants to input that.