### PR TITLE
warning when debug does not contain prefiltered gyro data

### DIFF
--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -391,7 +391,7 @@ class CSV_log:
         meanspec_max = np.max(meanspec*mask[:-1])
 
         if not self.check_lims_list(lims):
-            lims=np.array([[1,20],[1, 20], [1, 20], [0,meanspec_max*1.5]])
+            lims=np.array([[1,max_noise_gyro],[1, max_noise_debug], [1, max_noise_d], [0,meanspec_max*1.5]])
             if lims[0,1] == 1:
                 lims[0,1]=100.
             if lims[1, 1] == 1:
@@ -467,11 +467,6 @@ class CSV_log:
                                                       '- LPF only: set debug_mode = GYRO', horizontalalignment='center', verticalalignment = 'center',
                                                       transform = ax1.transAxes,fontdict={'color': 'white'})
 
-             if correctdebugmode == False: # if debug_mode not GYRO_SCALED, display warning
-                ax1.text(0.5, 0.5, 'warning: debug does not contain prefiltered gyro\n'
-                                                      'set debug_mode = GYRO_SCALED', horizontalalignment='center', verticalalignment = 'center',
-                                                      transform = ax1.transAxes,fontdict={'color': 'white'})
-                
             if i<2:
                 # dterm plots
                 ax2 = plt.subplot(gs1[1 + i * 8:1 + i * 8 + 8, 16:23])
@@ -680,8 +675,6 @@ class CSV_log:
     def readcsv(self, fpath):
         logging.info('Reading: Log '+str(self.headdict['logNum']))
         datdic = {}
-        global correctdebugmode
-        
         ### keycheck for 'usecols' only reads usefull traces, uncommend if needed
         wanted =  ['time (us)',
                    'rcCommand[0]', 'rcCommand[1]', 'rcCommand[2]', 'rcCommand[3]',
@@ -700,8 +693,6 @@ class CSV_log:
         datdic.update({'time_us': data['time (us)'].values * 1e-6})
         datdic.update({'throttle': data['rcCommand[3]'].values})
 
-        correctdebugmode = not np.any(data['debug[3]']) # if debug[3] contains data, correctdebugmode is False
-            
         for i in ['0', '1', '2']:
             datdic.update({'rcCommand' + i: data['rcCommand['+i+']'].values})
             #datdic.update({'PID loop in' + i: data['axisP[' + i + ']'].values})
@@ -973,7 +964,7 @@ if __name__ == "__main__":
         default=os.path.join(os.getcwd(), 'Blackbox_decode.exe'),
         help='Path to Blackbox_decode.exe.')
     parser.add_argument('-s', '--show', default='Y', help='Y = show plot window when done.\nN = Do not. \nDefault = Y')
-    parser.add_argument('-nb', '--noise_bounds', default='[[1.,20.],[1.,20.],[1.,20.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
+    parser.add_argument('-nb', '--noise_bounds', default='[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
     args = parser.parse_args()
 
     blackbox_decode_path = clean_path(args.blackbox_decode)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -391,7 +391,7 @@ class CSV_log:
         meanspec_max = np.max(meanspec*mask[:-1])
 
         if not self.check_lims_list(lims):
-            lims=np.array([[1,max_noise_gyro],[1, max_noise_debug], [1, max_noise_d], [0,meanspec_max*1.5]])
+            lims=np.array([[1,20],[1, 20], [1, 20], [0,meanspec_max*1.5]])
             if lims[0,1] == 1:
                 lims[0,1]=100.
             if lims[1, 1] == 1:

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -964,7 +964,7 @@ if __name__ == "__main__":
         default=os.path.join(os.getcwd(), 'Blackbox_decode.exe'),
         help='Path to Blackbox_decode.exe.')
     parser.add_argument('-s', '--show', default='Y', help='Y = show plot window when done.\nN = Do not. \nDefault = Y')
-    parser.add_argument('-nb', '--noise_bounds', default='[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
+    parser.add_argument('-nb', '--noise_bounds', default='[[1.,20.],[1.,20.],[1.,20.],[0.,4.]]', help='bounds of plots in noise analysis. use "auto" for autoscaling. \n default=[[1.,10.1],[1.,100.],[1.,100.],[0.,4.]]')
     args = parser.parse_args()
 
     blackbox_decode_path = clean_path(args.blackbox_decode)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -467,6 +467,11 @@ class CSV_log:
                                                       '- LPF only: set debug_mode = GYRO', horizontalalignment='center', verticalalignment = 'center',
                                                       transform = ax1.transAxes,fontdict={'color': 'white'})
 
+             if correctdebugmode == False: # if debug_mode not GYRO_SCALED, display warning
+                ax1.text(0.5, 0.5, 'warning: debug does not contain prefiltered gyro\n'
+                                                      'set debug_mode = GYRO_SCALED', horizontalalignment='center', verticalalignment = 'center',
+                                                      transform = ax1.transAxes,fontdict={'color': 'white'})
+                
             if i<2:
                 # dterm plots
                 ax2 = plt.subplot(gs1[1 + i * 8:1 + i * 8 + 8, 16:23])
@@ -675,6 +680,8 @@ class CSV_log:
     def readcsv(self, fpath):
         logging.info('Reading: Log '+str(self.headdict['logNum']))
         datdic = {}
+        global correctdebugmode
+        
         ### keycheck for 'usecols' only reads usefull traces, uncommend if needed
         wanted =  ['time (us)',
                    'rcCommand[0]', 'rcCommand[1]', 'rcCommand[2]', 'rcCommand[3]',
@@ -693,6 +700,8 @@ class CSV_log:
         datdic.update({'time_us': data['time (us)'].values * 1e-6})
         datdic.update({'throttle': data['rcCommand[3]'].values})
 
+        correctdebugmode = not np.any(data['debug[3]']) # if debug[3] contains data, correctdebugmode is False
+            
         for i in ['0', '1', '2']:
             datdic.update({'rcCommand' + i: data['rcCommand['+i+']'].values})
             #datdic.update({'PID loop in' + i: data['axisP[' + i + ']'].values})

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -466,6 +466,11 @@ class CSV_log:
                                                       '- all filters: set debug_mode = NOTCH\n'
                                                       '- LPF only: set debug_mode = GYRO', horizontalalignment='center', verticalalignment = 'center',
                                                       transform = ax1.transAxes,fontdict={'color': 'white'})
+                
+            if correctdebugmode == False:
+                ax1.text(0.5, 0.5, 'warning: debug does not contain prefiltered gyro\n'
+                                                      'set debug_mode = GYRO_SCALED', horizontalalignment='center', verticalalignment = 'center',
+                                                      transform = ax1.transAxes,fontdict={'color': 'white'})
 
             if i<2:
                 # dterm plots
@@ -675,6 +680,7 @@ class CSV_log:
     def readcsv(self, fpath):
         logging.info('Reading: Log '+str(self.headdict['logNum']))
         datdic = {}
+        global correctdebugmode
         ### keycheck for 'usecols' only reads usefull traces, uncommend if needed
         wanted =  ['time (us)',
                    'rcCommand[0]', 'rcCommand[1]', 'rcCommand[2]', 'rcCommand[3]',
@@ -692,6 +698,8 @@ class CSV_log:
         data = read_csv(fpath, header=0, skipinitialspace=1, usecols=lambda k: k in wanted, dtype=np.float64)
         datdic.update({'time_us': data['time (us)'].values * 1e-6})
         datdic.update({'throttle': data['rcCommand[3]'].values})
+        
+        correctdebugmode = not np.any(data['debug[3]']) # if debug[3] contains data, debug_mode is not correct for plotting 
 
         for i in ['0', '1', '2']:
             datdic.update({'rcCommand' + i: data['rcCommand['+i+']'].values})


### PR DESCRIPTION
I'd like to propose that the debug noise plots display a warning if the debug variable does not contain prefiltered gyro data. This would help avoid the confusion some people have when they have unknowingly selected the incorrect debug_mode in Betaflight, resulting in meaningless results in the debug subplots. An easy way to do this is to code when the 4th column of debug[3] is not empty indicating debug variable does not contain prefiltered gyro data. We could consider using debug_mode variable itself, but this wont work for certain earlier versions of BF. The solution I propose here involves 2 simple lines of code, the first (line 703) checks to see if debug[3] contains data (indicating incorrect debug_mode for most cases, since 4th column should be empty otherwise), and the second is a conditional statement (line 470) for presenting warning overlaid on debug subplots. There might be a more elegant way to do this, but this works.